### PR TITLE
Historial releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+releases/
+docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ before_install:
   - helm init --client-only
 script:
   - rake package
+  - rake clone
   - rake index
 deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  keep_history: true
-  local_dir: docs
-  on:
-    branch: master
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    keep_history: true
+    local_dir: docs
+    on:
+      branch: master

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ end
 
 desc "Clone existing releases"
 task :clone do
-  sh "git clone --depth 1 git@github.com:PrivateBin/helm-chart.git -b gh-pages releases/"
+  sh "git clone --depth 1 https://github.com/PrivateBin/helm-chart.git -b gh-pages releases/"
 end
 
 desc "Build packed helm charts"

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,11 @@ class Chart < OpenStruct
   end
 end
 
+desc "Clone existing releases"
+task :clone do
+  sh "git clone --depth 1 git@github.com:PrivateBin/helm-chart.git -b gh-pages releases/"
+end
+
 desc "Build packed helm charts"
 task package: Chart.targets
 
@@ -41,7 +46,9 @@ desc "Index the helm repo"
 task index: [WEB_ROOT, "#{WEB_ROOT}/index.yaml"]
 
 rule "#{WEB_ROOT}/index.yaml" => Chart.targets do
-  sh "helm repo index #{WEB_ROOT} --url #{REPO_URL}"
+  sh "mv releases/*.tgz #{WEB_ROOT}/"
+  sh "mv releases/index.yaml #{WEB_ROOT}/"
+  sh "helm repo index #{WEB_ROOT} --url #{REPO_URL} --merge #{WEB_ROOT}/index.yaml"
 end
 
 task :clean do


### PR DESCRIPTION
I realized that we were dropping all historical chart releases on each merge to master. This PR, along with #7, lets us retain existing releases in the index.

This PR should not be merged until #7 has been.