### PR TITLE
Add chart-testing via github actions

### DIFF
--- a/.ci/ct-config.yaml
+++ b/.ci/ct-config.yaml
@@ -1,0 +1,7 @@
+---
+remote: origin
+chart-dirs:
+  - charts
+chart-repos:
+  - privatebin=https://privatebin.github.io/helm-chart
+helm-extra-args: --timeout 800

--- a/.ci/kind-config.yaml
+++ b/.ci/kind-config.yaml
@@ -1,0 +1,6 @@
+---
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+  - role: control-plane
+  - role: worker

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   lint-and-test:
-    name: Lint and Test
+    name: Lint and Test ${{ matrix.kubernetesVersion }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -1,0 +1,46 @@
+---
+name: Lint and Test Chart
+on: pull_request
+
+jobs:
+  lint-and-test:
+    name: Lint and Test
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetesVersion: ["v1.14.10", "v1.15.7", "v1.16.4", "v1.17.2"]
+
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        with:
+          command: lint
+          config: .ci/ct-config.yaml
+
+      - name: Install kind
+        uses: helm/kind-action@v1.0.0-alpha.3
+        with:
+          node_image: "kindest/node:${{ matrix.kubernetesVersion }}"
+          config: .ci/kind-config.yaml
+          install_local_path_provisioner: true
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Verify kind
+        run: |
+          kubectl cluster-info
+          kubectl get nodes -o wide
+          kubectl get pods -n kube-system
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        with:
+          command: install
+          config: .ci/ct-config.yaml

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -8,7 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: ["v1.14.10", "v1.15.7", "v1.16.4", "v1.17.2"]
+        kubernetesVersion: [
+          "v1.14.10",
+          "v1.15.7",
+          "v1.16.4",
+          "v1.17.2",
+        ]
 
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -30,6 +30,7 @@ jobs:
           config: .ci/ct-config.yaml
 
       - name: Install kind
+        id: install-kind
         uses: helm/kind-action@v1.0.0-alpha.3
         with:
           node_image: "kindest/node:${{ matrix.kubernetesVersion }}"
@@ -39,17 +40,15 @@ jobs:
         if: steps.lint.outputs.changed == 'true'
 
       - name: Verify kind
+        needs: install-kind
         run: |
           kubectl cluster-info
           kubectl get nodes -o wide
           kubectl get pods -n kube-system
-        # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-alpha.3
+        needs: install-kind
         with:
           command: install
           config: .ci/ct-config.yaml
-        # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -30,7 +30,6 @@ jobs:
           config: .ci/ct-config.yaml
 
       - name: Install kind
-        id: install-kind
         uses: helm/kind-action@v1.0.0-alpha.3
         with:
           node_image: "kindest/node:${{ matrix.kubernetesVersion }}"
@@ -40,15 +39,17 @@ jobs:
         if: steps.lint.outputs.changed == 'true'
 
       - name: Verify kind
-        needs: install-kind
         run: |
           kubectl cluster-info
           kubectl get nodes -o wide
           kubectl get pods -n kube-system
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-alpha.3
-        needs: install-kind
         with:
           command: install
           config: .ci/ct-config.yaml
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -43,9 +43,13 @@ jobs:
           kubectl cluster-info
           kubectl get nodes -o wide
           kubectl get pods -n kube-system
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-alpha.3
         with:
           command: install
           config: .ci/ct-config.yaml
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'


### PR DESCRIPTION
Test the privatebin-helm chart the same way the core helm charts are tested.

I'd like to think about moving to github actions for deploying the helm repo to github pages as well.