### PR TITLE
Fix deployment spec

### DIFF
--- a/privatebin/Chart.yaml
+++ b/privatebin/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
-version: 0.6.0
+version: 0.6.1
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/privatebin/templates/deployment.yaml
+++ b/privatebin/templates/deployment.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "privatebin.name" . }}
@@ -23,6 +22,7 @@ spec:
         app.kubernetes.io/name: {{ include "privatebin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"


### PR DESCRIPTION
A comment was made in PR #29 where deployments were failing due to an incorrect API spec. I dug in and noticed the `serviceAccountName` was under the wrong spec within the template. This PR is to correct my mistake.