### PR TITLE
update container port

### DIFF
--- a/privatebin/Chart.yaml
+++ b/privatebin/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
-version: 0.6.1
+version: 0.6.2
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/privatebin/templates/statefulset.yaml
+++ b/privatebin/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
I should have remembered to change this here in the helm chart as well.

Back in https://github.com/PrivateBin/docker-nginx-fpm-alpine/commit/0c1a2e565cccbd459c768a942fd5ea9ecb2dbf84 I had changed the port to 8080, but still kept 80 for backwards compatibility, to allow the image to be used in environments where the use of ports below 1024 is disabled.

Earlier this year in I had then dropped the use of port 80 in https://github.com/PrivateBin/docker-nginx-fpm-alpine/commit/d83d136f458b32de985773b3cbbc9e079541da9c, to drop the need for capabilities, as some users ran the image on filesystems without capability support or where this was disabled.

I'm sorry this change broke the deployment. Hopefully we now have a hardened AND still highly compatible image, where we run the services as an unprivileged user, don't need any capabilities or privileged ports.

Fixes #33