### PR TITLE
Changes to STS to fit EKS deployment with gp2

### DIFF
--- a/privatebin/templates/statefulset.yaml
+++ b/privatebin/templates/statefulset.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  serviceName: {{ include "privatebin.fullname" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "privatebin.name" . }}

--- a/privatebin/templates/statefulset.yaml
+++ b/privatebin/templates/statefulset.yaml
@@ -22,6 +22,8 @@ spec:
         app.kubernetes.io/name: {{ include "privatebin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      securityContext:
+        fsGroup: 82
       serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}

--- a/privatebin/templates/statefulset.yaml
+++ b/privatebin/templates/statefulset.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  serviceName: {{ include "privatebin.fullname" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "privatebin.name" . }}
@@ -65,7 +66,7 @@ spec:
     - metadata:
         name: storage
       spec:
-        accessModes: [ "ReadWriteMany" ]
+        accessModes: [ "{{ .Values.controller.pvc.accessModes }}" ]
       {{- if .Values.controller.pvc.storageClass }}
         {{- if (eq "-" .Values.controller.pvc.storageClass) }}
         storageClassName: ""

--- a/privatebin/values.yaml
+++ b/privatebin/values.yaml
@@ -30,11 +30,15 @@ controller:
   kind: Deployment
   pvc:
     requests: "1Gi"
+    accessModes: "ReadWriteOnce"
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
+    ## Please be aware that gp2 supports only RWO, check with
+    ## this table:
+    ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
     ##
     # storageClass: "-"
 


### PR DESCRIPTION
Added fsGroup and set to 82.
Without this it breaks on EKS with gp2 as PV and StatefulSet as a kind.

Also ReadWriteMany is not allowed mode within gp2, so made it as a variable in values.

Introduced serviceName in statefulset since this is a mandatory.

related to #32 
Current changes are tested and running on EKS 1.17.12 as a statefulset with gp2 as a pv.
