### PR TITLE
remove override for chart-testing version since it doesn't exist

### DIFF
--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
-        with:
-          version: 3.5.2
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
we accidentally added a version override here in addition to the helm version