### PR TITLE
add master to branches for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
adds current default branch `master` to target branches for release workflow