### PR TITLE
remove init to chown config map

### DIFF
--- a/charts/privatebin/Chart.yaml
+++ b/charts/privatebin/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
-version: 0.10.0
+version: 0.10.1
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -38,17 +38,6 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-      initContainers:
-        - name: set-volume-permissions
-          image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
-          imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
-          command:
-            - -R
-            - "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}"
-            - /mnt
-          volumeMounts:
-            - name: storage
-              mountPath: /mnt
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -43,13 +43,12 @@ spec:
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
           imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
           command:
-            - chown
             - -R
             - "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}"
-            - /srv/cfg
+            - /mnt
           volumeMounts:
-            - name: configs
-              mountPath: /srv/cfg
+            - name: storage
+              mountPath: /mnt
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/privatebin/values.yaml
+++ b/charts/privatebin/values.yaml
@@ -43,8 +43,8 @@ controller:
 
 initChownData:
   image:
-    repository: busybox
-    tag: 1.31.1
+    repository: privatebin/chown
+    tag: 1.34.1-musl-1.2.2-r3
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/privatebin/values.yaml
+++ b/charts/privatebin/values.yaml
@@ -41,12 +41,6 @@ controller:
     ##
     # storageClass: "-"
 
-initChownData:
-  image:
-    repository: privatebin/chown
-    tag: 1.34.1-musl-1.2.2-r3
-    pullPolicy: IfNotPresent
-
 securityContext:
   runAsUser: 65534
   runAsGroup: 82


### PR DESCRIPTION
This PR intends to address #54 ~~with the assumption that we had wanted to adjust permissions in the `storage` volume (where the main container needs to write into), not the ConfigMap. It also switches the image used from `busybox` to [`privatebin/chown`](https://github.com/PrivateBin/docker-chown#readme), which contains just the `chown` binary compiled from busybox, though that change can reverted, if preferred.~~ [added in edit:] removing the chown of the config map. Kudos @reg0bs for pointing out the function of the `fsGroup` security context to me.