### PR TITLE
feat: drop 1.19 and bump other kind kubernetes versions

### DIFF
--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -9,10 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         kubernetesVersion: [
-          "v1.19.11",
           "v1.20.7",
-          "v1.21.1",
-          "v1.22.0"
+          "v1.21.2",
+          "v1.22.5",
+          "v1.23.3"
         ]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://kubernetes.io/releases/

Release[ ](https://kubernetes.io/releases/#release-history)[](https://kubernetes.io/releases/#release-v1-23)History 
1.23
Latest Release:1.23.3 (released: 2022-01-25)
End of Life:2023-02-28
Patch Releases: [1.23.1](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.23.md#v1231), [1.23.2](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.23.md#v1232), [1.23.3](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.23.md#v1233)
Complete 1.23 [Schedule](https://kubernetes.io/releases/patch-releases/#1-23) and [Changelog](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.23.md)[](https://kubernetes.io/releases/#release-v1-22)

1.22
Latest Release:1.22.6 (released: 2022-01-19)
End of Life:2022-10-28
Patch Releases: [1.22.1](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md#v1221), [1.22.2](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md#v1222), [1.22.3](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md#v1223), [1.22.4](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md#v1224), [1.22.5](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md#v1225), [1.22.6](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md#v1226)
Complete 1.22 [Schedule](https://kubernetes.io/releases/patch-releases/#1-22) and [Changelog](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.22.md)[](https://kubernetes.io/releases/#release-v1-21)

1.21
Latest Release:1.21.9 (released: 2022-01-19)
End of Life:2022-06-28
Patch Releases: [1.21.1](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1211), [1.21.2](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1212), [1.21.3](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1213), [1.21.4](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1214), [1.21.5](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1215), [1.21.6](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1216), [1.21.7](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1217), [1.21.8](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1218), [1.21.9](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md#v1219)
Complete 1.21 [Schedule](https://kubernetes.io/releases/patch-releases/#1-21) and [Changelog](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.21.md)[](https://kubernetes.io/releases/#release-v1-20)

1.20
Latest Release:[1.20.1](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1201)5 (released: 2022-01-19)
End of Life:2022-02-28
Patch Releases: 1.20.1, [1.20.2](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1202), [1.20.3](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1203), [1.20.4](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1204), [1.20.5](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1205), [1.20.6](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1206), [1.20.7](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1207), [1.20.8](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1208), [1.20.9](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v1209), [1.20.10](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v12010), [1.20.11](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v12011), [1.20.12](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v12012), [1.20.13](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v12013), [1.20.14](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v12014), [1.20.15](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md#v12015)
Complete 1.20 [Schedule](https://kubernetes.io/releases/patch-releases/#1-20) and [Changelog](https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.20.md)\