### PR TITLE
Better indentation for readability and fix annotations indentation

### DIFF
--- a/charts/privatebin/Chart.yaml
+++ b/charts/privatebin/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
-version: 0.11.0
+version: 0.12.0
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/charts/privatebin/templates/config.yaml
+++ b/charts/privatebin/templates/config.yaml
@@ -11,5 +11,5 @@ metadata:
 data:
 {{- range $key, $value := .Values.configs }}
   {{ $key }}: |-
-{{ $value | indent 4 }}
+    {{- $value | nindent 4 }}
 {{- end }}

--- a/charts/privatebin/templates/deployment.yaml
+++ b/charts/privatebin/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if .Values.additionalLabels }}
-      {{ toYaml .Values.additionalLabels | nindent 4 }}
+      {{- toYaml .Values.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -25,11 +25,11 @@ spec:
         app.kubernetes.io/name: {{ include "privatebin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- if .Values.additionalLabels }}
-          {{ toYaml .Values.additionalLabels | nindent 8 }}
+          {{- toYaml .Values.additionalLabels | nindent 8 }}
         {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
-        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ include "privatebin.serviceAccountName" . }}

--- a/charts/privatebin/templates/psp.yaml
+++ b/charts/privatebin/templates/psp.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{- if .Values.podSecurityPolicy.annotations }}
-{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
-{{- end }}
+  {{- if .Values.podSecurityPolicy.annotations }}
+    {{- toYaml .Values.podSecurityPolicy.annotations | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/charts/privatebin/templates/role.yaml
+++ b/charts/privatebin/templates/role.yaml
@@ -11,12 +11,12 @@ metadata:
 rules:
   {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:
-    - policy
+      - policy
     resourceNames:
-    - {{ include "privatebin.fullname" . }}
+      - {{ include "privatebin.fullname" . }}
     resources:
-    - podsecuritypolicies
+      - podsecuritypolicies
     verbs:
-    - use
+      - use
   {{- end }}
 {{- end -}}

--- a/charts/privatebin/templates/role.yaml
+++ b/charts/privatebin/templates/role.yaml
@@ -9,14 +9,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
-{{- if .Values.podSecurityPolicy.enabled }}
-- apiGroups:
-  - policy
-  resourceNames:
-  - {{ include "privatebin.fullname" . }}
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-{{- end }}
+  {{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups:
+    - policy
+    resourceNames:
+    - {{ include "privatebin.fullname" . }}
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+  {{- end }}
 {{- end -}}

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if .Values.additionalLabels }}
-      {{ toYaml .Values.additionalLabels | nindent 4 }}
+      {{- toYaml .Values.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -19,18 +19,18 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "privatebin.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }} 
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "privatebin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- if .Values.additionalLabels }}
-            {{ toYaml .Values.additionalLabels | nindent 8 }}
+            {{- toYaml .Values.additionalLabels | nindent 8 }}
           {{- end }}
         {{- if .Values.podAnnotations }}
         annotations:
-          {{ toYaml .Values.podAnnotations | nindent 8 }}
+          {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
@@ -69,14 +69,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       volumes:
         - name: configs
           configMap:
@@ -86,13 +86,13 @@ spec:
         name: storage
       spec:
         accessModes: [ "ReadWriteMany" ]
-      {{- if .Values.controller.pvc.storageClass }}
+        {{- if .Values.controller.pvc.storageClass }}
         {{- if (eq "-" .Values.controller.pvc.storageClass) }}
         storageClassName: ""
         {{- else }}
         storageClassName: "{{ .Values.controller.pvc.storageClass }}"
         {{- end }}
-      {{- end }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.controller.pvc.requests }}

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -26,12 +26,12 @@ spec:
         app.kubernetes.io/name: {{ include "privatebin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- if .Values.additionalLabels }}
-            {{- toYaml .Values.additionalLabels | nindent 8 }}
-          {{- end }}
-        {{- if .Values.podAnnotations }}
-        annotations:
-          {{- toYaml .Values.podAnnotations | nindent 8 }}
+          {{- toYaml .Values.additionalLabels | nindent 8 }}
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
       securityContext:


### PR DESCRIPTION
This PR improve the [readability of the chart code](https://github.com/Vampouille/helm-chart/commit/6b29df222baaad779bcb96b28a2e61609cbf9fcb) and [fix an issue with annotations](https://github.com/Vampouille/helm-chart/commit/69c789d926f410b36b9296372a0a90e7e0a37334) in the *Statefulset*.
With default `values.yaml` there is no difference in the rendered manifests but with the following modifications in `values.yaml` rendered manifests are different:

```diff                                                                                                                                          
@@ -13,8 +13,12 @@ image:
   # tag: latest # defaults to Chart.appVersion
   pullPolicy: IfNotPresent
 
-podAnnotations: {}
-additionalLabels: {}
+podAnnotations:
+  somePod: annotations
+  another: annotation
+additionalLabels:
+  newLabel: foo
+  anotherLabel: test
 
 nameOverride: ""
 fullnameOverride: ""
@@ -30,7 +34,7 @@ service:
 
 controller:
   # Valid values are "Deployment", "StatefulSet", and "Both"
-  kind: Deployment
+  kind: Both
   pvc:
     requests: "1Gi"
     ## If defined, storageClassName: <storageClass>
```

Differences in rendered manifests:
![Capture d’écran du 2022-03-01 08-39-27](https://user-images.githubusercontent.com/7067560/156126851-7295ab64-2bee-40d3-8990-90bb6324837d.png)
![Capture d’écran du 2022-03-01 08-37-50](https://user-images.githubusercontent.com/7067560/156126856-0b64839e-de81-43a4-aa6e-8d995004a83a.png)

