### PR TITLE
Allow setting readOnlyRootFilesystem

### DIFF
--- a/charts/privatebin/Chart.yaml
+++ b/charts/privatebin/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
-version: 0.14.0
+version: 0.15.0
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/charts/privatebin/templates/deployment.yaml
+++ b/charts/privatebin/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           securityContext:
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
             privileged: false
             allowPrivilegeEscalation: false
           livenessProbe:

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           securityContext:
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
             privileged: false
             allowPrivilegeEscalation: false
           livenessProbe:

--- a/charts/privatebin/values.yaml
+++ b/charts/privatebin/values.yaml
@@ -51,6 +51,7 @@ securityContext:
   runAsUser: 65534
   runAsGroup: 82
   fsGroup: 82
+  readOnlyRootFilesystem: true
 
 ingress:
   enabled: false


### PR DESCRIPTION
Fixes #60 

I've deliberately not changed the `PodSecurityPolicy` under the assumption that someone enabling the policy really wants the `readonlyrootfilesystem`. I'm still not sure how this can work anywhere since the image accesses and modifies `/run/`.