### PR TITLE
feat : enable configs values to be templated

### DIFF
--- a/charts/privatebin/templates/config.yaml
+++ b/charts/privatebin/templates/config.yaml
@@ -11,5 +11,5 @@ metadata:
 data:
 {{- range $key, $value := .Values.configs }}
   {{ $key }}: |-
-    {{- $value | nindent 4 }}
+    {{- tpl $value $ | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Add the possibility to use template syntax inside the configs sub-values

Since the config file `conf.php` need credentials for database connection, we should be able to fetch these credentials via vault and be able to insert them inside the configuration.

Example of this feature inside `Values.yaml ` file:

```
configs:
  conf.php: |-
    [main]
    ...
    [model]
    class = Database
    [model_options]
    dsn = "pgsql:host={{ $.Values.secrets.database.host }};dbname={{ $.Values.secrets.database.name }};charset=UTF8"
    tbl = "{{ $.Values.secrets.database.prefix }}"
    usr = "{{ $.Values.secrets.database.user }}"
    pwd = "{{ $.Values.secrets.database.password }}"
    opt[12] = true
```