### PR TITLE
fix(statefulset): remove duplicated securityContext key from template

### DIFF
--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -33,8 +33,6 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      securityContext:
-        fsGroup: 82
       serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}


### PR DESCRIPTION
This PR removes the duplicate securityContext from the statefulset template.
