### PR TITLE
fix:statefulset-security-context duplicate key

### DIFF
--- a/charts/privatebin/Chart.yaml
+++ b/charts/privatebin/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
-version: 0.14.0
+version: 0.14.1
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -33,8 +33,6 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      securityContext:
-        fsGroup: 82
       serviceAccountName: {{ include "privatebin.serviceAccountName" . }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}


### PR DESCRIPTION
This PR removed the duplicate securityContext from the statefulset template.

There is another PR #74  open but the owner of the PR is not responding, hence opening up a new PR to fix this.

Fyi.. @elrido 