### PR TITLE
feat: add extra volumes mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ See values.yaml for full documentation
 | `configs`                    | Optional Privatebin configuration file             | `{}`                                             |
 | `podAnnotations`             | Additional annotations to add to the pods          | `{}`                                             |
 | `additionalLabels`           | Additional labels to add to resources              | `{}`                                             |
+| `extraVolumes`               | Additional volumes to add to the pods              | `[]`                                             |
+| `extraVolumeMounts`          | Additional volume mounts to add to the pods        | `[]`                                             |
+
 
 ## Upgrades
 

--- a/charts/privatebin/templates/_helpers.tpl
+++ b/charts/privatebin/templates/_helpers.tpl
@@ -52,3 +52,16 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- print "policy/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "privatebin.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "privatebin.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/privatebin/templates/deployment.yaml
+++ b/charts/privatebin/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
               mountPath: /tmp
             - name: nginx-cache
               mountPath: /var/lib/nginx/tmp
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "privatebin.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -107,4 +110,7 @@ spec:
             medium: "Memory"
         - name: nginx-cache
           emptyDir: {}
+      {{- if .Values.extraVolumes }}
+      {{- include "privatebin.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/privatebin/templates/statefulset.yaml
+++ b/charts/privatebin/templates/statefulset.yaml
@@ -78,6 +78,9 @@ spec:
               mountPath: /tmp
             - name: nginx-cache
               mountPath: /var/lib/nginx/tmp
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "privatebin.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -102,6 +105,9 @@ spec:
             medium: "Memory"
         - name: nginx-cache
           emptyDir: {}
+      {{- if .Values.extraVolumes }}
+      {{- include "privatebin.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: storage

--- a/charts/privatebin/values.yaml
+++ b/charts/privatebin/values.yaml
@@ -59,6 +59,20 @@ securityContext:
   fsGroup: 82
   readOnlyRootFilesystem: true
 
+extraVolumes: []
+  # Optionally specify extra list of additional volumes for PrivateBin pod. 
+  # Example 
+  # - name: nginx-params
+  #   configMap:
+  #     name: nginx-params
+
+extraVolumeMounts: []
+  # Optionally specify extra list of additional volumeMounts for PrivateBin pod.
+  # Example
+  # - mountPath: /etc/nginx/server.d
+  #   name: nginx-params
+
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
Allows to customize Nginx or PHP parameters by mounting additional volumes. 
My changes for adding extraVolumes based on [bitnami wordpress chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress)