### PR TITLE
Fix overeager removing of whitespaces conflicting with helm lint

### DIFF
--- a/charts/privatebin/Chart.yaml
+++ b/charts/privatebin/Chart.yaml
@@ -6,7 +6,7 @@ name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
 type: application
-version: 0.17.0
+version: 0.17.1
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com

--- a/charts/privatebin/templates/ingress.yaml
+++ b/charts/privatebin/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.ingress.enabled -}}
+{{ if .Values.ingress.enabled -}}
 {{- $fullName := include "privatebin.fullname" . -}}
 {{- $svcPortName := .Values.service.portName -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/charts/privatebin/templates/serviceaccount.yaml
+++ b/charts/privatebin/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.rbac.create -}}
+{{ if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
helm lint (tested with latest at the time - 3.11.2) takes offense to all of the whitespaces being removed before or after a YAML document separator, as this consumes the newline separating the document separator and the apiVersion key immediately following as described in an issue submitted to the helm repository in 2021:
https://github.com/helm/helm/issues/10149
This pull request removes the excessive trimming of whitespaces, but a number of alternative solutions can be done, for instance, removing the YAML document separator at the top of the offending files.