### PR TITLE
feat(core): Upgrade PrivateBin to 1.5.2

### DIFF
--- a/charts/privatebin/Chart.yaml
+++ b/charts/privatebin/Chart.yaml
@@ -1,12 +1,12 @@
 ---
 apiVersion: v2
-appVersion: 1.5.1
+appVersion: 1.5.2
 description: A Helm chart for installing PrivateBin
 name: privatebin
 home: https://privatebin.info/
 icon: https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/icon.png
 type: application
-version: 0.18.0
+version: 0.19.0
 maintainers:
   - name: bdashrad
     email: bdashrad@gmail.com
@@ -20,7 +20,7 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade PrivateBin to 1.5.1
+      description: Upgrade PrivateBin to 1.5.2
   artifacthub.io/images: |
     - name: privatebin
-      image: privatebin/nginx-fpm-alpine:1.5.1
+      image: privatebin/nginx-fpm-alpine:1.5.2


### PR DESCRIPTION
This updates the chart to use the ([just released](https://privatebin.info/news/v1.5.2-release.html)) PrivateBin 1.5.2 by default.