### PR TITLE
Projected volumes for /srv/cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ See values.yaml for full documentation
 | `affinity`                   | Affinity or Anti-Affinity                          | `{}`                                             |
 | `topologySpreadConstraints`  | Topology Spread Constraints                        | `[]`                                             |
 | `configs`                    | Optional Privatebin configuration file             | `{}`                                             |
+| `configsAsProjected`         | Use a projected volume for the configs             | `{}`                                             |
+| `configsProjected`           | list of secrets and configMaps to include          | `{}`                                             |
+| `configsProjected.defaultMode`| default mount mode of the projected configs       | `420`                                            |
+| `configsProjected.secrets`   | secret configs to include                          | `nil`                                            |
+| `configsProjected.configMaps`| configMaps to include                              | `nil`                                            |
 | `podAnnotations`             | Additional annotations to add to the pods          | `{}`                                             |
 | `additionalLabels`           | Additional labels to add to resources              | `{}`                                             |
 | `extraVolumes`               | Additional volumes to add to the pods              | `[]`                                             |

--- a/charts/privatebin/templates/deployment.yaml
+++ b/charts/privatebin/templates/deployment.yaml
@@ -103,13 +103,26 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
+{{- if .Values.configsAsProjected }}
+        - name: configs
+          projected:
+            defaultMode: {{ default 420 .Values.configsProjected.defaultMode }}
+            sources:
+              - configMap:
+                  name: {{ include "privatebin.fullname" . }}-configs
+{{- range $cm := (default (list) .Values.configsProjected.configMaps) }}
+              - configMap:
+                  name: {{ $cm }}
+{{- end }}
+{{- range $sec := (default (list) .Values.configsProjected.secrets) }}
+              - secret:
+                  name: {{ $sec }}
+{{- end }}
+{{- else }}
         - name: configs
           configMap:
             name: {{ include "privatebin.fullname" . }}-configs
-        {{- if .Values.controller.emptyDir }}
-        - name: storage
-          emptyDir: {}
-        {{- end }}
+{{- end }}
         - name: run
           emptyDir:
             medium: "Memory"
@@ -118,6 +131,10 @@ spec:
             medium: "Memory"
         - name: nginx-cache
           emptyDir: {}
+        {{- if .Values.controller.emptyDir }}
+        - name: storage
+          emptyDir: {}
+        {{- end }}
       {{- if .Values.extraVolumes }}
       {{- include "privatebin.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/privatebin/values.yaml
+++ b/charts/privatebin/values.yaml
@@ -117,6 +117,15 @@ configs: {}
   # conf.php: |-
   #   ; see https://github.com/PrivateBin/PrivateBin/blob/master/cfg/conf.sample.php for config
 
+configsAsProjected: true
+configsProjected:
+  defaultMode: 420
+  #secrets:
+  #  - privatebin-conf     # the Secret that contains conf.php
+  # optionally, extra configmaps if you ever need them
+  # configMaps:
+  #   - some-other-config
+
 ## Enable RBAC
 rbac:
   create: false


### PR DESCRIPTION
I needed support for adding the conf.php as a secret due to it containing the database password.

Previously it was possible to configure it in the values file in `configs: {}` but that means putting everything in the values file.
Another possibility was to use `extraVolumes` and `extraVolumeMounts`, but the config file needs to be put in `/srv/cfg` and will conflict with the other volume mounts already in the chart.

A solution to combine everything is to use a projected volume.
This allows the following configuration where a list of secrets and config maps can be given:

```
configsAsProjected: true
configsProjected:
  defaultMode: 420
  secrets:
    - privatebin-secret
  configMaps:
    - privatebin-extraconfig
```

Example secret:

```
apiVersion: v1
kind: Secret
metadata:
  name: privatebin-secret
  namespace: default
data:
  conf.php: >-
    ...
type: Opaque
```

